### PR TITLE
bugfix/adc-config

### DIFF
--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -23,16 +23,6 @@
     machine = "Machine_1"
 [calculation.machine_name.variables]
 
-[calculation.power]
-    module="gen_electrical"
-    class="PowerToCurrent"
-[calculation.power.config]
-    line_voltage = 230
-    phases = 1
-[calculation.power.variables]
-    power_in = "power"
-    rms_current_out = "current_rms"
-
 [calculation.rms_current]
     module="gen_electrical"
     class="RMSToPeak"

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -3,7 +3,18 @@
     module="spi"
     class="SPI"
 [interface.spi0.config]
+    bus=0
     device=0
+    speed=1000000
+    mode=0
+[interface.spi1]
+    module="spi"
+    class="SPI"
+[interface.spi1.config]
+    bus=0
+    device=1
+    speed=1000000
+    mode=0
 
 #=-= Define Device Modules =-=
 [device.adc_0]

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -1,18 +1,17 @@
 #=-= Define Interface Modules =-=
-[interface.i2c0]
-    module="i2c"
-    class="I2C"
-[interface.i2c0.config]
-    bus=1
-    addr=0x48
+[interface.spi0]
+    module="spi"
+    class="SPI"
+[interface.spi0.config]
+    device=0
 
 #=-= Define Device Modules =-=
 [device.adc_0]
-    module="adc_grove"
-    class="PiHat"
-    interface="i2c0"
+    module="adc_MCP300X"
+    class="MCP3008"
+    interface="spi0"
 [device.adc_0.config]
-    adc_channel=3
+    adc_channel=0
 [device.adc_0.variables]
     v_in = "v_amp_out"
 

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -7,15 +7,6 @@
     addr=0x48
 
 #=-= Define Device Modules =-=
-#[device.adc_0]
-#    module="adc_ADS111X"
-#    class="ADS1115"
-#    interface="i2c0"
-#[device.adc_0.config]
-#    adc_channel=1
-#[device.adc_0.variables]
-#    v_in = "v_amp_out"
-
 [device.adc_0]
     module="adc_grove"
     class="PiHat"

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -25,7 +25,7 @@
 
 #=-= Define Device Modules =-=
 [device.adc_0]
-    module="adc_MCP300X"
+    module="adc_MCP300X"  # default to BC Robotics ADC
     class="MCP3008"
     interface="spi0"
 [device.adc_0.config]

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -16,6 +16,13 @@
     speed=1000000
     mode=0
 
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+    addr=0x48
+
 #=-= Define Device Modules =-=
 [device.adc_0]
     module="adc_MCP300X"

--- a/current_sensing/config/pm_b_1p.toml
+++ b/current_sensing/config/pm_b_1p.toml
@@ -21,7 +21,7 @@
     class="I2C"
 [interface.i2c0.config]
     bus=1
-    addr=0x48
+    addr=0x08
 
 #=-= Define Device Modules =-=
 [device.adc_0]

--- a/current_sensing/config/pm_b_3pb.toml
+++ b/current_sensing/config/pm_b_3pb.toml
@@ -25,7 +25,7 @@
 
 #=-= Define Device Modules =-=
 [device.adc_0]
-    module="adc_MCP300X"
+    module="adc_MCP300X"  # default to BC Robotics ADC
     class="MCP3008"
     interface="spi0"
 [device.adc_0.config]

--- a/current_sensing/config/pm_b_3pb.toml
+++ b/current_sensing/config/pm_b_3pb.toml
@@ -16,6 +16,13 @@
     speed=1000000
     mode=0
 
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+    addr=0x48
+
 #=-= Define Device Modules =-=
 [device.adc_0]
     module="adc_MCP300X"

--- a/current_sensing/config/pm_b_3pb.toml
+++ b/current_sensing/config/pm_b_3pb.toml
@@ -21,7 +21,7 @@
     class="I2C"
 [interface.i2c0.config]
     bus=1
-    addr=0x48
+    addr=0x08
 
 #=-= Define Device Modules =-=
 [device.adc_0]

--- a/current_sensing/config/pm_b_3pu.toml
+++ b/current_sensing/config/pm_b_3pu.toml
@@ -25,7 +25,7 @@
 
 #=-= Define Device Modules =-=
 [device.adc_0]
-    module="adc_MCP300X"
+    module="adc_MCP300X"  # default to BC Robotics ADC
     class="MCP3008"
     interface="spi0"
 [device.adc_0.config]
@@ -34,7 +34,7 @@
     v_in = "v_amp_out"
 
 [device.adc_1]
-    module="adc_MCP300X"
+    module="adc_MCP300X"  # default to BC Robotics ADC
     class="MCP3008"
     interface="spi0"
 [device.adc_1.config]
@@ -43,7 +43,7 @@
     v_in = "v_amp_out"
 
 [device.adc_2]
-    module="adc_MCP300X"
+    module="adc_MCP300X"  # default to BC Robotics ADC
     class="MCP3008"
     interface="spi0"
 [device.adc_2.config]

--- a/current_sensing/config/pm_b_3pu.toml
+++ b/current_sensing/config/pm_b_3pu.toml
@@ -16,6 +16,13 @@
     speed=1000000
     mode=0
 
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+    addr=0x48
+
 #=-= Define Device Modules =-=
 [device.adc_0]
     module="adc_MCP300X"

--- a/current_sensing/config/pm_b_3pu.toml
+++ b/current_sensing/config/pm_b_3pu.toml
@@ -21,7 +21,7 @@
     class="I2C"
 [interface.i2c0.config]
     bus=1
-    addr=0x48
+    addr=0x08
 
 #=-= Define Device Modules =-=
 [device.adc_0]

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -17,7 +17,35 @@ calculation.machine_name.config.machine = "Machine_Name_Here"
 # calculation.current_clamp.config.nominal_current = 50    # Amps for 1V output
 
 
-#   If using Basic hardware, set which adc you are using and which channels the clamps are plugged into.
+#   If using Basic hardware, set which adc you are using by uncommenting on of these blocks:
+[device.adc_0]
+    module="adc_MCP300X" # for the BC Robotics ADC
+    class="MCP3008"
+    interface="spi0"
+#[device.adc_0]
+#    module="adc_grove" # for the Grove Base Hat ADC
+#    class="PiHat"
+#    interface="i2c0"
+
+#   If using Basic hardware with multiple clamps, do the same for adc_1 (the second clamp) and adc_2 (the third clamp)
+[device.adc_1]
+    module="adc_MCP300X" # for the BC Robotics ADC
+    class="MCP3008"
+    interface="spi0"
+#[device.adc_1]
+#    module="adc_grove" # for the Grove Base Hat ADC
+#    class="PiHat"
+#    interface="i2c0"
+[device.adc_2]
+    module="adc_MCP300X" # for the BC Robotics ADC
+    class="MCP3008"
+    interface="spi0"
+#[device.adc_2]
+#    module="adc_grove" # for the Grove Base Hat ADC
+#    class="PiHat"
+#    interface="i2c0"
+
+#   If using Basic hardware, set which adc channels the clamps are plugged into.
 #   If using Intermediate or Advanced hardware, comment all these out with a #
 # device.adc_0.config.adc_channel = 0
 # device.adc_1.config.adc_channel = 1                      # If using multiple clamps


### PR DESCRIPTION
The purpose of this PR is to restore user-friendly support for both BC Robotics and Grove ADC hats to Power Monitoring. 

The basic sensing config files - `pm_b_1p.toml`, `pm_b_3pb.toml`, `pm_b_3pu.toml` - should be similar. Some have missed updates. 

Fixes #14 , #15 , #29 
Work TBD, still draft. 