### PR TITLE
Feature/Support for Gravity direct current sensor

### DIFF
--- a/current_sensing/code/core/calculation_modules/gen_calibrate.py
+++ b/current_sensing/code/core/calculation_modules/gen_calibrate.py
@@ -26,3 +26,27 @@ class MultiplierOffset:
         except Exception:
             logger.error(traceback.format_exc())
         return var_dict
+
+
+class OffsetMultiplier:
+    def __init__(self, config,variables):
+        self.multiplier = config.get('multiplier',1)
+        self.offset = config.get('offset',0)
+
+        self.raw_value = variables.get('raw_value')
+        self.calibrated_value = variables.get('calibrated_value', self.raw_value)
+
+    def calculate(self, var_dict):
+        try:
+            # Get variable containing output value
+            value = var_dict[self.raw_value]
+            if value is not None:
+                # Divide by gain to get input value
+                out = (value + self.offset) * self.multiplier
+                # Set the input variable
+                var_dict[self.calibrated_value] = out
+            else:
+                logger.warning(f"MultiplierOffset: raw variable '{self.raw_value}' not found")
+        except Exception:
+            logger.error(traceback.format_exc())
+        return var_dict

--- a/current_sensing/config/pm_dc_gravity_ads1115.toml
+++ b/current_sensing/config/pm_dc_gravity_ads1115.toml
@@ -1,0 +1,76 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.calibrate]
+    module="gen_calibrate"
+    class="MultiplierOffset"
+[calculation.calibrate.config]
+    offset = -25.09             # Empirically tuned at 5V supply & 0-7A. Guess nominal=multiplier*midsupply
+    multiplier = 9.61           # Guess nominal 10
+[calculation.calibrate.variables]
+    raw_value = "v_amp_out"
+    calibrated_value = "current"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    single_clamp = ["calibrate","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="SingleSampleAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "single_clamp"
+    constants = {'phase'='single'}
+
+[output.overall]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.overall.message_spec]
+    timestamp = '$.timestamp'
+    power = '$.power'
+    current = "$.current"
+    phase = "$.phase"
+    machine="$.machine"
+
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_dc_gravity_ads1115.toml
+++ b/current_sensing/config/pm_dc_gravity_ads1115.toml
@@ -54,7 +54,6 @@
     topic = "power_monitoring/{{machine}}/{{phase}}"
 [output.overall.message_spec]
     timestamp = '$.timestamp'
-    power = '$.power'
     current = "$.current"
     phase = "$.phase"
     machine="$.machine"

--- a/current_sensing/config/pm_dc_gravity_ads1115.toml
+++ b/current_sensing/config/pm_dc_gravity_ads1115.toml
@@ -26,10 +26,10 @@
 
 [calculation.calibrate]
     module="gen_calibrate"
-    class="MultiplierOffset"
+    class="OffsetMultiplier"
 [calculation.calibrate.config]
-    offset = -25.09             # Empirically tuned at 5V supply & 0-7A. Guess nominal=multiplier*midsupply
-    multiplier = 9.61           # Guess nominal 10
+    offset = -1.642             # Emperically tuned. Nominal midsupply 3V3/2.
+    multiplier = 15.62          # Emperically tuned 0-7A.
 [calculation.calibrate.variables]
     raw_value = "v_amp_out"
     calibrated_value = "current"

--- a/current_sensing/config/pm_dc_gravity_bc_robotics.toml
+++ b/current_sensing/config/pm_dc_gravity_bc_robotics.toml
@@ -56,7 +56,6 @@
     topic = "power_monitoring/{{machine}}/{{phase}}"
 [output.overall.message_spec]
     timestamp = '$.timestamp'
-    power = '$.power'
     current = "$.current"
     phase = "$.phase"
     machine="$.machine"

--- a/current_sensing/config/pm_dc_gravity_bc_robotics.toml
+++ b/current_sensing/config/pm_dc_gravity_bc_robotics.toml
@@ -28,10 +28,10 @@
 
 [calculation.calibrate]
     module="gen_calibrate"
-    class="MultiplierOffset"
-[calculation.calibrate.config]  # These values are a blind guess.
-    offset = -15.86             # = (3.3V/2)*multiplier
-    multiplier = 9.61           # Kept the same as empirically found with ADS1115
+    class="OffsetMultiplier"
+[calculation.calibrate.config]
+    offset = -1.61              # Slightly less offset required in empirical tuning. Nominal midsupply 3V3/2
+    multiplier = 15.62
 [calculation.calibrate.variables]
     raw_value = "v_amp_out"
     calibrated_value = "current"

--- a/current_sensing/config/pm_dc_gravity_bc_robotics.toml
+++ b/current_sensing/config/pm_dc_gravity_bc_robotics.toml
@@ -1,0 +1,78 @@
+#=-= Define Interface Modules =-=
+[interface.spi0]
+    module="spi"
+    class="SPI"
+[interface.spi0.config]
+    bus=0
+    device=0
+    speed=1000000
+    mode=0
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_MCP300X"
+    class="MCP3008"
+    interface="spi0"
+[device.adc_0.config]
+    adc_channel=0
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.calibrate]
+    module="gen_calibrate"
+    class="MultiplierOffset"
+[calculation.calibrate.config]  # These values are a blind guess.
+    offset = -15.86             # = (3.3V/2)*multiplier
+    multiplier = 9.61           # Kept the same as empirically found with ADS1115
+[calculation.calibrate.variables]
+    raw_value = "v_amp_out"
+    calibrated_value = "current"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    single_clamp = ["calibrate","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="SingleSampleAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "single_clamp"
+    constants = {'phase'='single'}
+
+[output.overall]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.overall.message_spec]
+    timestamp = '$.timestamp'
+    power = '$.power'
+    current = "$.current"
+    phase = "$.phase"
+    machine="$.machine"
+
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_dc_gravity_grove.toml
+++ b/current_sensing/config/pm_dc_gravity_grove.toml
@@ -1,0 +1,75 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_grove"
+    class="PiHat"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.calibrate]
+    module="gen_calibrate"
+    class="MultiplierOffset"
+[calculation.calibrate.config]  # These values are a blind guess.
+    offset = -15.86             # = (3.3V/2)*multiplier
+    multiplier = 9.61           # Kept the same as empirically found with ADS1115
+[calculation.calibrate.variables]
+    raw_value = "v_amp_out"
+    calibrated_value = "current"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    single_clamp = ["calibrate","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="SingleSampleAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "single_clamp"
+    constants = {'phase'='single'}
+
+[output.overall]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.overall.message_spec]
+    timestamp = '$.timestamp'
+    power = '$.power'
+    current = "$.current"
+    phase = "$.phase"
+    machine="$.machine"
+
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_dc_gravity_grove.toml
+++ b/current_sensing/config/pm_dc_gravity_grove.toml
@@ -53,7 +53,6 @@
     topic = "power_monitoring/{{machine}}/{{phase}}"
 [output.overall.message_spec]
     timestamp = '$.timestamp'
-    power = '$.power'
     current = "$.current"
     phase = "$.phase"
     machine="$.machine"

--- a/current_sensing/config/pm_dc_gravity_grove.toml
+++ b/current_sensing/config/pm_dc_gravity_grove.toml
@@ -25,10 +25,10 @@
 
 [calculation.calibrate]
     module="gen_calibrate"
-    class="MultiplierOffset"
-[calculation.calibrate.config]  # These values are a blind guess.
-    offset = -15.86             # = (3.3V/2)*multiplier
-    multiplier = 9.61           # Kept the same as empirically found with ADS1115
+    class="OffsetMultiplier"
+[calculation.calibrate.config]
+    offset = -1.642             # Emperically tuned. Nominal midsupply 3V3/2.
+    multiplier = 15.62          # Emperically tuned 0-7A.
 [calculation.calibrate.variables]
     raw_value = "v_amp_out"
     calibrated_value = "current"

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -33,7 +33,7 @@ calculation.machine_name.config.machine = "Machine_Name_Here"
 #calculation.current_clamp.config.nominal_current = 50          # Amps for 1V output
 
 
-#   If using Basic hardware, set which ADC you are using and which channels the clamp(s) are plugged into.
+#   If using Basic hardware, set which ADC channels the clamp(s) are plugged into.
 #   If using Intermediate or Advanced hardware, leave all these commented out.
 #device.adc_0.config.adc_channel = 0
 #device.adc_1.config.adc_channel = 2                            # If using multiple clamps

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -7,6 +7,7 @@
 #module_config_file = "./config/pm_b_3pb_grove.toml"        # Three phase balanced (single clamp) with Grove ADC
 #module_config_file = "./config/pm_b_3pu_bc_robotics.toml"  # Three phase unbalanced (Three clamps) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pu_grove.toml"        # Three phase unbalanced (Three clamps) with Grove ADC
+#module_config_file = "./config/pm_dc_gravity_ads1115.toml" # Gravity DC current sensor connected to ADS1115 ADC
 #
 #   Intermediate:
 #module_config_file = "./config/pm_i_1p.toml"               # Single phase

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -25,13 +25,13 @@ module_config_file = "./config/pm_b_3pu_mock.toml"          # Basic three phase 
 calculation.machine_name.config.machine = "Machine_Name_Here"
 
 
-#   If using Basic hardware, set the ratio of the current transformer clamps (written on the clamp).
+#   If using Basic AC hardware, set the ratio of the current transformer clamps (written on the clamp).
 #   For Intermediate and Advanced hardware this is the current in that produces 5A out
 #   and needs to be set on the multifunction Meter - leave commented out here.
 #calculation.current_clamp.config.nominal_current = 50      # Amps for 1V output
 
 
-#   If using Basic hardware, set which adc you are using and which channels the clamps are plugged into.
+#   If using Basic hardware, set which ADC you are using and which channels the clamp(s) are plugged into.
 #   If using Intermediate or Advanced hardware, leave all these commented out.
 #device.adc_0.config.adc_channel = 0
 #device.adc_1.config.adc_channel = 2                        # If using multiple clamps

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -1,24 +1,26 @@
 #   Select the config file (by removing the leading #) appropriate for your hardware and wiring setup
 #
 #   Basic:
-#module_config_file = "./config/pm_b_1p_bc_robotics.toml"   # Single phase with BC Robotics ADC
-#module_config_file = "./config/pm_b_1p_grove.toml"         # Single phase with Grove ADC
-#module_config_file = "./config/pm_b_3pb_bc_robotics.toml"  # Three phase balanced (single clamp) with BC Robotics ADC
-#module_config_file = "./config/pm_b_3pb_grove.toml"        # Three phase balanced (single clamp) with Grove ADC
-#module_config_file = "./config/pm_b_3pu_bc_robotics.toml"  # Three phase unbalanced (Three clamps) with BC Robotics ADC
-#module_config_file = "./config/pm_b_3pu_grove.toml"        # Three phase unbalanced (Three clamps) with Grove ADC
-#module_config_file = "./config/pm_dc_gravity_ads1115.toml" # Gravity DC current sensor connected to ADS1115 ADC
+#module_config_file = "./config/pm_b_1p_bc_robotics.toml"       # Single phase with BC Robotics ADC
+#module_config_file = "./config/pm_b_1p_grove.toml"             # Single phase with Grove ADC
+#module_config_file = "./config/pm_b_3pb_bc_robotics.toml"      # Three phase balanced (single clamp) with BC Robotics ADC
+#module_config_file = "./config/pm_b_3pb_grove.toml"            # Three phase balanced (single clamp) with Grove ADC
+#module_config_file = "./config/pm_b_3pu_bc_robotics.toml"      # Three phase unbalanced (Three clamps) with BC Robotics ADC
+#module_config_file = "./config/pm_b_3pu_grove.toml"            # Three phase unbalanced (Three clamps) with Grove ADC
+#module_config_file = "./config/pm_dc_gravity_ads1115.toml"     # Gravity DC current sensor connected to ADS1115 ADC
+#module_config_file = "./config/pm_dc_gravity_bc_robotics.toml" # Gravity DC current sensor connected to BC Robotics ADC
+#module_config_file = "./config/pm_dc_gravity_grove.toml"       # Gravity DC current sensor connected to Grove ADC
 #
 #   Intermediate:
-#module_config_file = "./config/pm_i_1p.toml"               # Single phase
-#module_config_file = "./config/pm_i_3p.toml"               # Three phase
+#module_config_file = "./config/pm_i_1p.toml"                   # Single phase
+#module_config_file = "./config/pm_i_3p.toml"                   # Three phase
 #
 #   Advanced (inc. voltage monitoring):
-#module_config_file = "./config/pm_a_1p.toml"               # Single phase
-#module_config_file = "./config/pm_a_3p.toml"               # Three phase
+#module_config_file = "./config/pm_a_1p.toml"                   # Single phase
+#module_config_file = "./config/pm_a_3p.toml"                   # Three phase
 #
 #   Simulator for testing without sensing hardware:
-module_config_file = "./config/pm_b_3pu_mock.toml"          # Basic three phase unbalanced simulator
+module_config_file = "./config/pm_b_3pu_mock.toml"              # Basic three phase unbalanced simulator
 
 
 #   Set the machine name
@@ -28,11 +30,11 @@ calculation.machine_name.config.machine = "Machine_Name_Here"
 #   If using Basic AC hardware, set the ratio of the current transformer clamps (written on the clamp).
 #   For Intermediate and Advanced hardware this is the current in that produces 5A out
 #   and needs to be set on the multifunction Meter - leave commented out here.
-#calculation.current_clamp.config.nominal_current = 50      # Amps for 1V output
+#calculation.current_clamp.config.nominal_current = 50          # Amps for 1V output
 
 
 #   If using Basic hardware, set which ADC you are using and which channels the clamp(s) are plugged into.
 #   If using Intermediate or Advanced hardware, leave all these commented out.
 #device.adc_0.config.adc_channel = 0
-#device.adc_1.config.adc_channel = 2                        # If using multiple clamps
-#device.adc_2.config.adc_channel = 4                        # If using multiple clamps
+#device.adc_1.config.adc_channel = 2                            # If using multiple clamps
+#device.adc_2.config.adc_channel = 4                            # If using multiple clamps


### PR DESCRIPTION
If we are preparing a DC current power monitoring solution for SMDH, we may as well keep the code. 
Even if we don't want to keep it long term, I'm uncomfortable shipping an untagged, let alone untracked, version.

This PR adds toml config files for DC current sensing. The solution otherwise works for DC, only the assumed DC voltage needs to be set matching the machine name in `analysis/config/user_config.toml`
It also adds DC support for an ADC previously unused for Power Monitoring, the ADS1115. 

All ADCs can use 3V3. Although the ADS1115 supports 5V input, I propose to keep it on 3V3 for consistency. In testing (with a 3V3 logic supply) up to 7A, I have found amps in : volt out to always be ~15, hence the sensor has linear range for 1.65*15 = ±24.75A, in excess of the sensor's ±20A rating.

The consequences I don't like:
- The list of config presets is getting long. More so if we go on to add the 3 AC ones for the ADS1115.
- Setting the ratio isn't as easy as it is with AC CTs.