### PR TITLE
Removed power from basic current sensing MQTT messages

### DIFF
--- a/current_sensing/config/pm_b_1p_bc_robotics.toml
+++ b/current_sensing/config/pm_b_1p_bc_robotics.toml
@@ -71,7 +71,6 @@
     topic = "power_monitoring/{{machine}}/{{phase}}"
 [output.overall.message_spec]
     timestamp = '$.timestamp'
-    power = '$.power'
     current = "$.current_rms"
     phase = "$.phase"
     machine="$.machine"

--- a/current_sensing/config/pm_b_1p_grove.toml
+++ b/current_sensing/config/pm_b_1p_grove.toml
@@ -68,7 +68,6 @@
     topic = "power_monitoring/{{machine}}/{{phase}}"
 [output.overall.message_spec]
     timestamp = '$.timestamp'
-    power = '$.power'
     current = "$.current_rms"
     phase = "$.phase"
     machine="$.machine"

--- a/current_sensing/config/pm_b_3pb_bc_robotics.toml
+++ b/current_sensing/config/pm_b_3pb_bc_robotics.toml
@@ -66,14 +66,6 @@
     device = "adc_0"
     pipeline = "rms_current"
 
-# [output.overall]
-#     path = "power_monitoring/{{machine}}/{{phase}}"
-# [output.overall.spec]
-#     timestamp = '$.timestamp'
-#     power = '$.power'
-#     current = "$.current_rms"
-#     phase = "$.phase"
-#     machine="#Machine_1"
 
 [output.phase_a]
     topic = "power_monitoring/{{machine}}/{{phase}}"
@@ -90,7 +82,6 @@
     timestamp = '$.timestamp'
     current = "$.current_rms"
     phase = "#B"
-
 
 [output.phase_c]
     topic = "power_monitoring/{{machine}}/{{phase}}"

--- a/current_sensing/config/pm_b_3pb_grove.toml
+++ b/current_sensing/config/pm_b_3pb_grove.toml
@@ -63,14 +63,6 @@
     device = "adc_0"
     pipeline = "rms_current"
 
-# [output.overall]
-#     path = "power_monitoring/{{machine}}/{{phase}}"
-# [output.overall.spec]
-#     timestamp = '$.timestamp'
-#     power = '$.power'
-#     current = "$.current_rms"
-#     phase = "$.phase"
-#     machine="#Machine_1"
 
 [output.phase_a]
     topic = "power_monitoring/{{machine}}/{{phase}}"
@@ -87,7 +79,6 @@
     timestamp = '$.timestamp'
     current = "$.current_rms"
     phase = "#B"
-
 
 [output.phase_c]
     topic = "power_monitoring/{{machine}}/{{phase}}"

--- a/current_sensing/config/pm_b_3pu_bc_robotics.toml
+++ b/current_sensing/config/pm_b_3pu_bc_robotics.toml
@@ -93,14 +93,6 @@
     pipeline = "rms_current"
     constants = {'phase'='C'}
 
-# [output.overall]
-#     path = "power_monitoring/{{machine}}/{{phase}}"
-# [output.overall.spec]
-#     timestamp = '$.timestamp'
-#     power = '$.power'
-#     current = "$.current_rms"
-#     phase = "$.phase"
-#     machine="#Machine_1"
 
 [output.phase]
     topic = "power_monitoring/{{machine}}/{{phase}}"

--- a/current_sensing/config/pm_b_3pu_grove.toml
+++ b/current_sensing/config/pm_b_3pu_grove.toml
@@ -90,14 +90,6 @@
     pipeline = "rms_current"
     constants = {'phase'='C'}
 
-# [output.overall]
-#     path = "power_monitoring/{{machine}}/{{phase}}"
-# [output.overall.spec]
-#     timestamp = '$.timestamp'
-#     power = '$.power'
-#     current = "$.current_rms"
-#     phase = "$.phase"
-#     machine="#Machine_1"
 
 [output.phase]
     topic = "power_monitoring/{{machine}}/{{phase}}"

--- a/current_sensing/config/pm_b_3pu_mock.toml
+++ b/current_sensing/config/pm_b_3pu_mock.toml
@@ -92,14 +92,6 @@
     pipeline = "rms_current"
     constants = {'phase'='C'}
 
-# [output.overall]
-#     path = "power_monitoring/{{machine}}/{{phase}}"
-# [output.overall.spec]
-#     timestamp = '$.timestamp'
-#     power = '$.power'
-#     current = "$.current_rms"
-#     phase = "$.phase"
-#     machine="#Machine_1"
 
 [output.phase]
     topic = "power_monitoring/{{machine}}/{{phase}}"


### PR DESCRIPTION
Fixes #42 

In basic configurations Power is now provided by the analysis module. This PR removes artifacts from when the voltage assumption and power calculation was done in the current dc module.

Also removed commented blocks which are now outdated and would me misleading to keep.
Also made paragraph spacing a tiny bit more consistent where files were already being edited.