### PR TITLE
Make simulator less realistic 

### DIFF
--- a/current_sensing/config/pm_b_3pu_mock.toml
+++ b/current_sensing/config/pm_b_3pu_mock.toml
@@ -10,8 +10,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_0.config]
-    min=1800
-    max=2000
+    min=18000
+    max=20000
 [device.adc_0.variables]
     variable = "v_amp_out"
 
@@ -20,8 +20,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_1.config]
-    min=1600
-    max=1800
+    min=16000
+    max=18000
 [device.adc_1.variables]
     variable = "v_amp_out"
 
@@ -30,8 +30,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_2.config]
-    min=1600
-    max=1900
+    min=16000
+    max=19000
 [device.adc_2.variables]
     variable = "v_amp_out"
 

--- a/current_sensing/config/pm_b_3pu_mock.toml
+++ b/current_sensing/config/pm_b_3pu_mock.toml
@@ -10,8 +10,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_0.config]
-    min=1.8
-    max=2
+    min=18
+    max=20
 [device.adc_0.variables]
     variable = "v_amp_out"
 
@@ -20,8 +20,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_1.config]
-    min=1.6
-    max=1.8
+    min=16
+    max=18
 [device.adc_1.variables]
     variable = "v_amp_out"
 
@@ -30,8 +30,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_2.config]
-    min=1.6
-    max=1.9
+    min=16
+    max=19
 [device.adc_2.variables]
     variable = "v_amp_out"
 

--- a/current_sensing/config/pm_b_3pu_mock.toml
+++ b/current_sensing/config/pm_b_3pu_mock.toml
@@ -10,8 +10,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_0.config]
-    min=18
-    max=20
+    min=1800
+    max=2000
 [device.adc_0.variables]
     variable = "v_amp_out"
 
@@ -20,8 +20,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_1.config]
-    min=16
-    max=18
+    min=1600
+    max=1800
 [device.adc_1.variables]
     variable = "v_amp_out"
 
@@ -30,8 +30,8 @@
     class="MockDeviceRandom"
     interface="dummy"
 [device.adc_2.config]
-    min=16
-    max=19
+    min=1600
+    max=1900
 [device.adc_2.variables]
     variable = "v_amp_out"
 


### PR DESCRIPTION
We've often said we should, but I can't find any evidence of doing, making the simulator less realistic. 

Users (such as myself) oft get confused that the simulated data looks plausible but then doesn't exactly match the hardware situation. Let's make the simulated data so silly that there is no question of if that is sensed data. 