### PR TITLE
Feature/ ADS1115 support for AC power monitoring

### DIFF
--- a/current_sensing/config/pm_b_1p_ads1115.toml
+++ b/current_sensing/config/pm_b_1p_ads1115.toml
@@ -1,0 +1,90 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 20
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    single_clamp = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="SingleSampleAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "single_clamp"
+    constants = {'phase'='single'}
+
+[output.overall]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.overall.message_spec]
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "$.phase"
+    machine="$.machine"
+
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_b_1p_ads1115.toml
+++ b/current_sensing/config/pm_b_1p_ads1115.toml
@@ -12,7 +12,7 @@
     interface="i2c0"
 [device.adc_0.config]
     adc_channel=0
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_0.variables]
     v_in = "v_amp_out"
 

--- a/current_sensing/config/pm_b_3pb_ads1115.toml
+++ b/current_sensing/config/pm_b_3pb_ads1115.toml
@@ -1,0 +1,109 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 50
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    rms_current = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="MultiSampleIndividualAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "rms_current"
+
+
+[output.phase_a]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_a.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#A"
+
+[output.phase_b]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_b.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#B"
+
+[output.phase_c]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_c.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#C"
+
+
+[mqtt]
+    # URL of the mqtt broker
+    broker = "mqtt.docker.local"
+    # Port to use when connecting to the broker
+    port = 1883   #common mqtt ports are 1883 and 8883
+    # prefix to prepend to the topic of all published messages
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_b_3pb_ads1115.toml
+++ b/current_sensing/config/pm_b_3pb_ads1115.toml
@@ -12,7 +12,7 @@
     interface="i2c0"
 [device.adc_0.config]
     adc_channel=0
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_0.variables]
     v_in = "v_amp_out"
 

--- a/current_sensing/config/pm_b_3pu_ads1115.toml
+++ b/current_sensing/config/pm_b_3pu_ads1115.toml
@@ -1,0 +1,120 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Device Modules =-=
+[device.adc_2]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=2
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Device Modules =-=
+[device.adc_2]
+    module="adc_ADS111X"
+    class="ADS1115"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=4
+    gain="6.114V"
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 50
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    rms_current = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="MultiSampleIndividualAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "rms_current"
+    constants = {'phase'='A'}
+[[measurement.sensing_stacks]]
+    device = "adc_1"
+    pipeline = "rms_current"
+    constants = {'phase'='B'}
+[[measurement.sensing_stacks]]
+    device = "adc_2"
+    pipeline = "rms_current"
+    constants = {'phase'='C'}
+
+
+[output.phase]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "$.phase"
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_b_3pu_ads1115.toml
+++ b/current_sensing/config/pm_b_3pu_ads1115.toml
@@ -17,14 +17,14 @@
     v_in = "v_amp_out"
 
 #=-= Define Device Modules =-=
-[device.adc_2]
+[device.adc_1]
     module="adc_ADS111X"
     class="ADS1115"
     interface="i2c0"
-[device.adc_0.config]
-    adc_channel=2
+[device.adc_1.config]
+    adc_channel=1
     gain="6.114V"
-[device.adc_0.variables]
+[device.adc_1.variables]
     v_in = "v_amp_out"
 
 #=-= Define Device Modules =-=
@@ -32,10 +32,10 @@
     module="adc_ADS111X"
     class="ADS1115"
     interface="i2c0"
-[device.adc_0.config]
-    adc_channel=4
+[device.adc_2.config]
+    adc_channel=3
     gain="6.114V"
-[device.adc_0.variables]
+[device.adc_2.variables]
     v_in = "v_amp_out"
 
 #=-= Define Calculation Modules =-=

--- a/current_sensing/config/pm_b_3pu_ads1115.toml
+++ b/current_sensing/config/pm_b_3pu_ads1115.toml
@@ -12,7 +12,7 @@
     interface="i2c0"
 [device.adc_0.config]
     adc_channel=0
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_0.variables]
     v_in = "v_amp_out"
 
@@ -23,7 +23,7 @@
     interface="i2c0"
 [device.adc_1.config]
     adc_channel=1
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_1.variables]
     v_in = "v_amp_out"
 
@@ -34,7 +34,7 @@
     interface="i2c0"
 [device.adc_2.config]
     adc_channel=3
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_2.variables]
     v_in = "v_amp_out"
 

--- a/current_sensing/config/pm_dc_gravity_ads1115.toml
+++ b/current_sensing/config/pm_dc_gravity_ads1115.toml
@@ -12,7 +12,7 @@
     interface="i2c0"
 [device.adc_0.config]
     adc_channel=0
-    gain="6.114V"
+    gain="6.144V"
 [device.adc_0.variables]
     v_in = "v_amp_out"
 

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -1,12 +1,15 @@
 #   Select the config file (by removing the leading #) appropriate for your hardware and wiring setup
 #
 #   Basic:
+#module_config_file = "./config/pm_b_1p_ads1115.toml"           # Single phase with ADS1115 ADC
 #module_config_file = "./config/pm_b_1p_bc_robotics.toml"       # Single phase with BC Robotics ADC
 #module_config_file = "./config/pm_b_1p_grove_v1.0.toml"        # Single phase with Grove ADC v1.0
 #module_config_file = "./config/pm_b_1p_grove_v1.1.toml"        # Single phase with Grove ADC v1.1
+#module_config_file = "./config/pm_b_3pb_ads1115.toml"          # Three phase balanced (single clamp) with ADS1115 ADC
 #module_config_file = "./config/pm_b_3pb_bc_robotics.toml"      # Three phase balanced (single clamp) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pb_grove_v1.0.toml"       # Three phase balanced (single clamp) with Grove ADC v1.0
 #module_config_file = "./config/pm_b_3pb_grove_v1.1.toml"       # Three phase balanced (single clamp) with Grove ADC v1.1
+#module_config_file = "./config/pm_b_3pu_ads1115.toml"          # Three phase unbalanced (Three clamps) with ADS1115 ADC
 #module_config_file = "./config/pm_b_3pu_bc_robotics.toml"      # Three phase unbalanced (Three clamps) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pu_grove_v1.0.toml"       # Three phase unbalanced (Three clamps) with Grove ADC v1.0
 #module_config_file = "./config/pm_b_3pu_grove_v1.1.toml"       # Three phase unbalanced (Three clamps) with Grove ADC v1.1


### PR DESCRIPTION
Seeing how easy it might be to add AC support for the ADS1115. 
Took the BC Robotics config files for 1ph, 3pb and 3pu, and replaced the interface modules and device modules with blocks inspired by how DC power monitoring used the ADS1115.