### PR TITLE
Added channel number validation to basic ADCs

### DIFF
--- a/current_sensing/code/core/device_modules/adc_ADS111X.py
+++ b/current_sensing/code/core/device_modules/adc_ADS111X.py
@@ -48,7 +48,7 @@ class ADS1115:
             self.speed, self.sample_delay = self.ADS111X_SAMPLE_SPEEDS.get('128SPS')
 
         self.i2c = None
-
+        self.channel_mask = 0b11
         self.input_variable = variables['v_in']
 
     def initialise(self, interface):
@@ -84,7 +84,15 @@ class ADS1115:
         msb |= 1 << 7  # start single shot conversion
         if not self.differential:
             msb |= 0b1 << 6
-        msb |= (self.channel & 0b11) << 4
+            
+        # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception at the end of sample() to log these.
+        if not isinstance(self.channel, int):
+            raise TypeError("ADS1115 supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel) + " not an int")
+            
+        elif (self.channel < 0) or (self.channel > self.channel_mask):
+            raise ValueError("ADS1115 supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
+        
+        msb |= (self.channel & self.channel_mask) << 4
         msb |= self.gain << 1
         msb |= 0b1  # single shot mode
 

--- a/current_sensing/code/core/device_modules/adc_ADS111X.py
+++ b/current_sensing/code/core/device_modules/adc_ADS111X.py
@@ -85,7 +85,7 @@ class ADS1115:
         if not self.differential:
             msb |= 0b1 << 6
 
-        # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception at the end of sample() to log these.
+        # Check channel number is valid. Must be an int between 0 and self.channel_mask inclusive.
         if not isinstance(self.channel, int):
             raise TypeError("ADS1115 supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
 

--- a/current_sensing/code/core/device_modules/adc_ADS111X.py
+++ b/current_sensing/code/core/device_modules/adc_ADS111X.py
@@ -84,14 +84,14 @@ class ADS1115:
         msb |= 1 << 7  # start single shot conversion
         if not self.differential:
             msb |= 0b1 << 6
-            
+
         # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception at the end of sample() to log these.
         if not isinstance(self.channel, int):
-            raise TypeError("ADS1115 supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel) + " not an int")
-            
+            raise TypeError("ADS1115 supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
+
         elif (self.channel < 0) or (self.channel > self.channel_mask):
             raise ValueError("ADS1115 supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
-        
+
         msb |= (self.channel & self.channel_mask) << 4
         msb |= self.gain << 1
         msb |= 0b1  # single shot mode

--- a/current_sensing/code/core/device_modules/adc_MCP300X.py
+++ b/current_sensing/code/core/device_modules/adc_MCP300X.py
@@ -22,6 +22,13 @@ class MCP3008:
 
     def sample(self):
         try:
+            # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception below to log these.
+            if not isinstance(self.channel, int):
+                raise TypeError("MCP300X supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel) + " not an int")
+                
+            elif (self.channel < 0) or (self.channel > self.channel_mask):
+                raise ValueError("MCP300X supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
+            
             # prepare config byte
             config_byte = ((0b1000 if self.differential else 0b0) | (self.channel & self.channel_mask))
             # perform reading
@@ -31,6 +38,7 @@ class MCP3008:
             adc_reading = ((buffer_out[1] & 0b11) << 8) + buffer_out[2]
             voltage = (adc_reading / self.ADCMax) * self.ADCVoltage
             return {self.input_variable: voltage}
+
         except Exception as e:
             logger.error(traceback.format_exc())
             raise e

--- a/current_sensing/code/core/device_modules/adc_MCP300X.py
+++ b/current_sensing/code/core/device_modules/adc_MCP300X.py
@@ -24,11 +24,11 @@ class MCP3008:
         try:
             # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception below to log these.
             if not isinstance(self.channel, int):
-                raise TypeError("MCP300X supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel) + " not an int")
-                
+                raise TypeError("MCP300X supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
+
             elif (self.channel < 0) or (self.channel > self.channel_mask):
                 raise ValueError("MCP300X supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
-            
+
             # prepare config byte
             config_byte = ((0b1000 if self.differential else 0b0) | (self.channel & self.channel_mask))
             # perform reading

--- a/current_sensing/code/core/device_modules/adc_MCP300X.py
+++ b/current_sensing/code/core/device_modules/adc_MCP300X.py
@@ -22,7 +22,7 @@ class MCP3008:
 
     def sample(self):
         try:
-            # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception below to log these.
+            # Check channel number is valid. Must be an int between 0 and self.channel_mask inclusive.
             if not isinstance(self.channel, int):
                 raise TypeError("MCP300X supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
 

--- a/current_sensing/code/core/device_modules/adc_grove.py
+++ b/current_sensing/code/core/device_modules/adc_grove.py
@@ -32,7 +32,7 @@ class PiHat:
         try:
             # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception below to log these.
             if not isinstance(self.channel, int):
-                raise TypeError("PiHat supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel) + " not an int")
+                raise TypeError("PiHat supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
                 
             elif (self.channel < 0) or (self.channel > self.channel_mask):
                 raise ValueError("PiHat supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))

--- a/current_sensing/code/core/device_modules/adc_grove.py
+++ b/current_sensing/code/core/device_modules/adc_grove.py
@@ -30,7 +30,7 @@ class PiHat:
 
     def sample(self):
         try:
-            # Check channel number is valid. How should errors be logged / raised in this context? I expect the except Exception below to log these.
+            # Check channel number is valid. Must be an int between 0 and self.channel_mask inclusive.
             if not isinstance(self.channel, int):
                 raise TypeError("PiHat supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
                 


### PR DESCRIPTION
Not a proper fix to #46 , but at least trying to raise an appropriate error rather than return the wrong data.

Checks that channel numbers supplied are integers. Check that these integers are within the range supported by the ADC. 

I have so far implemented this at the lowest level (per-adc files). Perhaps this could be repeated less if it were done slightly higher up in the sensing module? Any ADC has a finite range of channels it can sample from.