### PR TITLE
Feature/sequent adc

### DIFF
--- a/current_sensing/code/core/device_modules/adc_sequent.py
+++ b/current_sensing/code/core/device_modules/adc_sequent.py
@@ -24,14 +24,14 @@ class Sequent16chADC:
             # Check channel number is valid. Must be an int between 1 and self.channel_mask inclusive.
             if not isinstance(self.channel, int):
                 raise TypeError("Sequent16chADC supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
-                
+
             elif (self.channel < 1) or (self.channel > self.channel_mask):  # As marked on silkscreen, this ADC's lowest channel is 1.
                 raise ValueError("Sequent16chADC supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
 
             # prepare register byte
             register_addr = 6 + ((self.channel - 1) * 2)
 
-            # perform reading
+            # perform reading. If stop=True, readings can glitch when monitoring multiple machines simultaneously. 
             readings = self.i2c.read_register(self.i2c_address, register_addr, 2, stop=False)
 
             # calculate voltage

--- a/current_sensing/code/core/device_modules/adc_sequent.py
+++ b/current_sensing/code/core/device_modules/adc_sequent.py
@@ -1,0 +1,45 @@
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Sequent16chADC:
+    ADCMax = 10000 # conversion to mV done on hardware
+
+    def __init__(self, config, variables):
+        self.channel = config.get('adc_channel')            # No default value here, must be configured
+        self.i2c_address = config.get('i2c_address',0x58)   # Use stack number?
+        self.ADCVoltage = config.get('v_ref', 10)           # 10V max reading range
+        self.i2c = None                                     # Interface created in initialise()
+        self.channel_mask = 16                              # maximum valid channel number
+
+        self.input_variable = variables['v_in']
+
+    def initialise(self, interface):
+        self.i2c = interface
+
+    def sample(self):
+        try:
+            # Check channel number is valid. Must be an int between 1 and self.channel_mask inclusive.
+            if not isinstance(self.channel, int):
+                raise TypeError("Sequent16chADC supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
+                
+            elif (self.channel < 1) or (self.channel > self.channel_mask):  # As marked on silkscreen, this ADC' lowest channel is 1.
+                raise ValueError("Sequent16chADC supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
+
+            # prepare register byte
+            register_addr = 6 + ((self.channel - 1) * 2)
+
+            # perform reading
+            readings = self.i2c.read_register(self.i2c_address, register_addr, 2, stop=True)
+
+            # calculate voltage
+            adc_reading = (readings[1] << 8) + readings[0]
+            voltage = (adc_reading / self.ADCMax) * self.ADCVoltage     # In this particular case could also directly divide by 1000
+
+            return {self.input_variable: voltage}
+
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            raise e

--- a/current_sensing/code/core/device_modules/adc_sequent.py
+++ b/current_sensing/code/core/device_modules/adc_sequent.py
@@ -32,7 +32,7 @@ class Sequent16chADC:
             register_addr = 6 + ((self.channel - 1) * 2)
 
             # perform reading
-            readings = self.i2c.read_register(self.i2c_address, register_addr, 2, stop=True)
+            readings = self.i2c.read_register(self.i2c_address, register_addr, 2, stop=False)
 
             # calculate voltage
             adc_reading = (readings[1] << 8) + readings[0]

--- a/current_sensing/code/core/device_modules/adc_sequent.py
+++ b/current_sensing/code/core/device_modules/adc_sequent.py
@@ -31,7 +31,7 @@ class Sequent16chADC:
             # prepare register byte
             register_addr = 6 + ((self.channel - 1) * 2)
 
-            # perform reading. If stop=True, readings can glitch when monitoring multiple machines simultaneously. 
+            # perform reading. If stop=True, readings can glitch when monitoring multiple machines simultaneously.
             readings = self.i2c.read_register(self.i2c_address, register_addr, 2, stop=False)
 
             # calculate voltage

--- a/current_sensing/code/core/device_modules/adc_sequent.py
+++ b/current_sensing/code/core/device_modules/adc_sequent.py
@@ -25,7 +25,7 @@ class Sequent16chADC:
             if not isinstance(self.channel, int):
                 raise TypeError("Sequent16chADC supplied with channel " + str(self.channel) + " which is a " + str(type(self.channel)) + " not an int")
                 
-            elif (self.channel < 1) or (self.channel > self.channel_mask):  # As marked on silkscreen, this ADC' lowest channel is 1.
+            elif (self.channel < 1) or (self.channel > self.channel_mask):  # As marked on silkscreen, this ADC's lowest channel is 1.
                 raise ValueError("Sequent16chADC supplied with channel number " + str(self.channel) + " cannot be negative or greater than mask " + str(self.channel_mask))
 
             # prepare register byte

--- a/current_sensing/config/pm_b_1p_sequent.toml
+++ b/current_sensing/config/pm_b_1p_sequent.toml
@@ -1,0 +1,90 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_sequent"
+    class="Sequent16chADC"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    i2c_address = 0x58
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 20
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    single_clamp = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="SingleSampleAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "single_clamp"
+    constants = {'phase'='single'}
+
+[output.overall]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.overall.message_spec]
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "$.phase"
+    machine="$.machine"
+
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_b_3pb_sequent.toml
+++ b/current_sensing/config/pm_b_3pb_sequent.toml
@@ -1,0 +1,109 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_sequent"
+    class="Sequent16chADC"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    i2c_address = 0x58
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 50
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    rms_current = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="MultiSampleIndividualAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "rms_current"
+
+
+[output.phase_a]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_a.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#A"
+
+[output.phase_b]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_b.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#B"
+
+[output.phase_c]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase_c.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "#C"
+
+
+[mqtt]
+    # URL of the mqtt broker
+    broker = "mqtt.docker.local"
+    # Port to use when connecting to the broker
+    port = 1883   #common mqtt ports are 1883 and 8883
+    # prefix to prepend to the topic of all published messages
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/pm_b_3pu_sequent.toml
+++ b/current_sensing/config/pm_b_3pu_sequent.toml
@@ -1,0 +1,116 @@
+#=-= Define Interface Modules =-=
+[interface.i2c0]
+    module="i2c"
+    class="I2C"
+[interface.i2c0.config]
+    bus=1
+
+#=-= Define Device Modules =-=
+[device.adc_0]
+    module="adc_sequent"
+    class="Sequent16chADC"
+    interface="i2c0"
+[device.adc_0.config]
+    adc_channel=0
+    i2c_address = 0x58
+[device.adc_0.variables]
+    v_in = "v_amp_out"
+
+[device.adc_1]
+    module="adc_sequent"
+    class="Sequent16chADC"
+    interface="i2c0"
+[device.adc_1.config]
+    adc_channel=0
+[device.adc_1.variables]
+    v_in = "v_amp_out"
+    
+[device.adc_2]
+    module="adc_sequent"
+    class="Sequent16chADC"
+    interface="i2c0"
+[device.adc_2.config]
+    adc_channel=0
+[device.adc_2.variables]
+    v_in = "v_amp_out"
+
+#=-= Define Calculation Modules =-=
+[calculation.machine_name]
+    module="gen_constants"
+    class="ConstantSet"
+[calculation.machine_name.config]
+    machine = "Machine_1"
+[calculation.machine_name.variables]
+
+[calculation.rms_current]
+    module="gen_electrical"
+    class="RMSToPeak"
+[calculation.rms_current.variables]
+    var_in = "current_rms"
+    var_out = "clamp_current"
+
+[calculation.current_clamp]
+    module="gen_current_clamp"
+    class="VoltageClamp"
+[calculation.current_clamp.config]
+    nominal_current = 50
+[calculation.current_clamp.variables]
+    current_in = "clamp_current"
+    voltage_out = "v_amp_in"
+
+[calculation.amplifier]
+    module="gen_amplifier"
+    class="GenAmplifier"
+[calculation.amplifier.config]
+    gain = 2
+[calculation.amplifier.variables]
+    amp_input = "v_amp_in"
+    amp_output = "v_amp_out"
+
+#=-= Define Calculation Pipelines =-=
+[pipelines]
+    rms_current = ["rms_current","current_clamp","amplifier","machine_name"]
+
+#=-= Define Measurements Pipelines =-=
+[measurement]
+    module="gen_sample"
+    class="MultiSampleIndividualAvg"
+[measurement.config]
+    period = 1.0 # seconds
+    n_samples = 5
+[[measurement.sensing_stacks]]
+    device = "adc_0"
+    pipeline = "rms_current"
+    constants = {'phase'='A'}
+[[measurement.sensing_stacks]]
+    device = "adc_1"
+    pipeline = "rms_current"
+    constants = {'phase'='B'}
+[[measurement.sensing_stacks]]
+    device = "adc_2"
+    pipeline = "rms_current"
+    constants = {'phase'='C'}
+
+
+[output.phase]
+    topic = "power_monitoring/{{machine}}/{{phase}}"
+[output.phase.message_spec]
+    machine = "$.machine"
+    timestamp = '$.timestamp'
+    current = "$.current_rms"
+    phase = "$.phase"
+
+[mqtt]
+    broker = "mqtt.docker.local"
+    port = 1883   #common mqtt ports are 1883 and 8883
+    topic_prefix = ""
+
+    #reconnection characteristics
+    # start: timeout = initial,
+    # if timeout < limit then
+    #   timeout = timeout*backoff
+    # else
+    #   timeout = limit
+    reconnect.initial = 5 # seconds
+    reconnect.backoff = 2 # multiplier
+    reconnect.limit = 60 # seconds

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -10,10 +10,12 @@
 #module_config_file = "./config/pm_b_3pb_bc_robotics.toml"      # Three phase balanced (single clamp) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pb_grove_v1.0.toml"       # Three phase balanced (single clamp) with Grove ADC v1.0
 #module_config_file = "./config/pm_b_3pb_grove_v1.1.toml"       # Three phase balanced (single clamp) with Grove ADC v1.1
+#module_config_file = "./config/pm_b_3pb_sequent.toml"          # Three phase balanced (single clamp) with Sequent 16 channel Universal Inputs ADC
 #module_config_file = "./config/pm_b_3pu_ads1115.toml"          # Three phase unbalanced (Three clamps) with ADS1115 ADC
 #module_config_file = "./config/pm_b_3pu_bc_robotics.toml"      # Three phase unbalanced (Three clamps) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pu_grove_v1.0.toml"       # Three phase unbalanced (Three clamps) with Grove ADC v1.0
 #module_config_file = "./config/pm_b_3pu_grove_v1.1.toml"       # Three phase unbalanced (Three clamps) with Grove ADC v1.1
+#module_config_file = "./config/pm_b_3pu_sequent.toml"          # Three phase unbalanced (Three clamps) with Sequent 16 channel Universal Inputs ADC
 #module_config_file = "./config/pm_dc_gravity_ads1115.toml"     # Gravity DC current sensor connected to ADS1115 ADC
 #module_config_file = "./config/pm_dc_gravity_bc_robotics.toml" # Gravity DC current sensor connected to BC Robotics ADC
 #module_config_file = "./config/pm_dc_gravity_grove_v1.0.toml"  # Gravity DC current sensor connected to Grove ADC v1.0

--- a/current_sensing/config/user_config.toml
+++ b/current_sensing/config/user_config.toml
@@ -5,6 +5,7 @@
 #module_config_file = "./config/pm_b_1p_bc_robotics.toml"       # Single phase with BC Robotics ADC
 #module_config_file = "./config/pm_b_1p_grove_v1.0.toml"        # Single phase with Grove ADC v1.0
 #module_config_file = "./config/pm_b_1p_grove_v1.1.toml"        # Single phase with Grove ADC v1.1
+#module_config_file = "./config/pm_b_1p_sequent.toml"           # Single phase with Sequent 16 channel Universal Inputs ADC
 #module_config_file = "./config/pm_b_3pb_ads1115.toml"          # Three phase balanced (single clamp) with ADS1115 ADC
 #module_config_file = "./config/pm_b_3pb_bc_robotics.toml"      # Three phase balanced (single clamp) with BC Robotics ADC
 #module_config_file = "./config/pm_b_3pb_grove_v1.0.toml"       # Three phase balanced (single clamp) with Grove ADC v1.0


### PR DESCRIPTION
Support for a new ADC: the Sequent Microsystems 16 universal inputs card 
https://sequentmicrosystems.com/products/sixteen-analog-digital-inputs-8-layer-stackable-hat-for-raspberry-pi

This ADC has 16 channels each to a depth of 12 bits.

It does not have convenient 3.3V available for the amplifier, so some wiring has to be done to make use of this. It remains a backup to the more convenient BC Robotics ADC.