### PR TITLE
Dashboard consistency

### DIFF
--- a/dashboards/config/dashboards/Power Monitoring/hist-all.json
+++ b/dashboards/config/dashboards/Power Monitoring/hist-all.json
@@ -546,7 +546,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [
@@ -640,7 +640,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},

--- a/dashboards/config/dashboards/Power Monitoring/hist-all.json
+++ b/dashboards/config/dashboards/Power Monitoring/hist-all.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 5,
   "links": [
     {
       "asDropdown": true,
@@ -81,7 +81,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -144,7 +144,7 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "limited_window = if int(v: v.windowPeriod) > int(v: 5s) then v.windowPeriod else 5s\r\n\r\nfrom(bucket: \"${const_bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"equipment_power_usage\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"current\")\r\n  |> aggregateWindow(every: limited_window, fn: mean, createEmpty: false)\r\n  |> pivot(columnKey: [\"_field\"], rowKey: [\"_time\"], valueColumn: \"_value\")\r\n  |> group(columns: [\"machine\",\"_time\"])\r\n  |> sum(column: \"current\")\r\n  |> group(columns: [\"machine\"])\r\n  |> keep(columns: [\"current\",\"_time\",\"machine\"])",
+          "query": "limited_window = if int(v: v.windowPeriod) > int(v: 5s) then v.windowPeriod else 5s\r\n\r\nfrom(bucket: \"${const_bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"equipment_power_usage\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"current\")\r\n  |> aggregateWindow(every: limited_window, fn: mean, createEmpty: true)\r\n  |> pivot(columnKey: [\"_field\"], rowKey: [\"_time\"], valueColumn: \"_value\")\r\n  |> group(columns: [\"machine\",\"_time\"])\r\n  |> sum(column: \"current\")\r\n  |> group(columns: [\"machine\"])\r\n  |> keep(columns: [\"current\",\"_time\",\"machine\"])",
           "refId": "B"
         }
       ],
@@ -294,7 +294,7 @@
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": false,
+            "spanNulls": 60000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -546,6 +546,7 @@
       "type": "timeseries"
     }
   ],
+  "refresh": "5s",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [
@@ -566,7 +567,7 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "1h",
           "value": "1h"
         },
@@ -639,13 +640,13 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Historic (All)",
   "uid": "sPrzJ-nSk",
-  "version": 2,
+  "version": 4,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/hist-idv.json
+++ b/dashboards/config/dashboards/Power Monitoring/hist-idv.json
@@ -430,7 +430,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "5s",
+  "refresh": "",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [
@@ -548,7 +548,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},

--- a/dashboards/config/dashboards/Power Monitoring/hist-idv.json
+++ b/dashboards/config/dashboards/Power Monitoring/hist-idv.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
+  "id": 6,
   "links": [
     {
       "asDropdown": true,
@@ -430,7 +430,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "revision": 1,
   "schemaVersion": 39,
   "tags": [
@@ -448,9 +448,10 @@
       },
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "Machine_1",
-          "value": "Machine_1"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -547,13 +548,13 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Historic (Individual)",
   "uid": "B25PaV7Sk",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/live_all.json
+++ b/dashboards/config/dashboards/Power Monitoring/live_all.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": 7,
   "links": [
     {
       "asDropdown": true,
@@ -359,13 +359,13 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Live (All)",
   "uid": "tqo0A-nIk",
-  "version": 6,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/live_idv.json
+++ b/dashboards/config/dashboards/Power Monitoring/live_idv.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
+  "id": 8,
   "links": [
     {
       "asDropdown": true,
@@ -269,7 +269,7 @@
           "refId": "A"
         }
       ],
-      "title": "Voltage",
+      "title": "Measured Voltage",
       "type": "stat"
     },
     {
@@ -579,9 +579,10 @@
       },
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "Machine_1",
-          "value": "Machine_1"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -603,13 +604,13 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Live (Individual)",
   "uid": "UJ85b47Iz",
-  "version": 6,
+  "version": 3,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/live_idv_simple.json
+++ b/dashboards/config/dashboards/Power Monitoring/live_idv_simple.json
@@ -328,9 +328,10 @@
       },
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "Lab_Int_3PU",
-          "value": "Lab_Int_3PU"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -352,13 +353,13 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Live (Individual) (Simple)",
   "uid": "edhihd155ubr4e",
-  "version": 3,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/trend_all.json
+++ b/dashboards/config/dashboards/Power Monitoring/trend_all.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 3,
   "links": [
     {
       "asDropdown": true,
@@ -416,6 +416,6 @@
   "timezone": "browser",
   "title": "Trend (All)",
   "uid": "i6b8d74Ik",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/trend_indv.json
+++ b/dashboards/config/dashboards/Power Monitoring/trend_indv.json
@@ -336,9 +336,10 @@
       },
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "Machine_1",
-          "value": "Machine_1"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "influxdb",
@@ -440,6 +441,6 @@
   "timezone": "browser",
   "title": "Trend (Individual)",
   "uid": "YrR-YV7Ik",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/dashboards/config/dashboards/Power Monitoring/trend_indv.json
+++ b/dashboards/config/dashboards/Power Monitoring/trend_indv.json
@@ -434,7 +434,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
Minor edits to all dashboards to make them more consistent.

* All dashboard json files end with one blank line
* Live dashboards have a time range of Last 5 Minutes, Historic 6 hours and Trend 7 Days.
* Live dashboards refresh every 5s, Historic and Trend do not autorefresh 
* `createEmpty: true` and `Connect Null Values: Threshold <1m` where appropriate (fixes #59 )
* Removed `Machine_1` etc from dashboard json files (machine variable is None)
* Voltage display renamed to Measured Voltage (for consistency with power factor)