### PR TITLE
Add spi1 interface to BCR module config files

### DIFF
--- a/current_sensing/config/pm_b_1p_bc_robotics.toml
+++ b/current_sensing/config/pm_b_1p_bc_robotics.toml
@@ -4,7 +4,16 @@
     class="SPI"
 [interface.spi0.config]
     bus=0
-    device=0
+    device=0 # chip enable 0
+    speed=1000000
+    mode=0
+
+[interface.spi1]
+    module="spi"
+    class="SPI"
+[interface.spi1.config]
+    bus=0
+    device=1 # chip enable 1
     speed=1000000
     mode=0
 

--- a/current_sensing/config/pm_b_3pb_bc_robotics.toml
+++ b/current_sensing/config/pm_b_3pb_bc_robotics.toml
@@ -4,7 +4,16 @@
     class="SPI"
 [interface.spi0.config]
     bus=0
-    device=0
+    device=0 # chip enable 0
+    speed=1000000
+    mode=0
+
+[interface.spi1]
+    module="spi"
+    class="SPI"
+[interface.spi1.config]
+    bus=0
+    device=1 # chip enable 1
     speed=1000000
     mode=0
 

--- a/current_sensing/config/pm_b_3pu_bc_robotics.toml
+++ b/current_sensing/config/pm_b_3pu_bc_robotics.toml
@@ -4,7 +4,16 @@
     class="SPI"
 [interface.spi0.config]
     bus=0
-    device=0
+    device=0 # chip enable 0
+    speed=1000000
+    mode=0
+
+[interface.spi1]
+    module="spi"
+    class="SPI"
+[interface.spi1.config]
+    bus=0
+    device=1 # chip enable 1
     speed=1000000
     mode=0
 

--- a/current_sensing/config/pm_dc_gravity_bc_robotics.toml
+++ b/current_sensing/config/pm_dc_gravity_bc_robotics.toml
@@ -4,7 +4,16 @@
     class="SPI"
 [interface.spi0.config]
     bus=0
-    device=0
+    device=0 # chip enable 0
+    speed=1000000
+    mode=0
+
+[interface.spi1]
+    module="spi"
+    class="SPI"
+[interface.spi1.config]
+    bus=0
+    device=1 # chip enable 1
     speed=1000000
     mode=0
 


### PR DESCRIPTION
As per action planned in https://github.com/DigitalShoestringSolutions/PowerMonitoring/issues/46#issuecomment-2647522510, this adds an unused spi1 interface to the config files that use the BCR ADC HAT.

To use channels above 7 on the BCR HAT, a user must add something like:
```
device.adc_n.interface="spi1"
device.adc_n.config.adc_channel = 3 # 12th channel on the BCR HAT = channel 3 on the upper bank
```
to `user_config.toml`. Still not friendly, but much improved.

This is most likely to be desired when monitoring multiple machines from the same HAT, [which is now supported](https://community.digitalshoestring.net/t/monitoring-multiple-machines-at-once-on-a-single-raspberry-pi/477/1).